### PR TITLE
Add `IAllocator`, `StackAllocator`, `HeapAllocator`

### DIFF
--- a/docs/user-guide/a2-05-cpu-target-specific.md
+++ b/docs/user-guide/a2-05-cpu-target-specific.md
@@ -1,0 +1,144 @@
+---
+layout: user-guide
+permalink: /user-guide/cpu-target-specific
+---
+
+# CPU-Specific Functionalities
+
+This chapter provides information for functionalities and behaviors in Slang
+that are specific to CPU execution.
+
+## Compilation paths
+
+There are two ways to emit CPU code: Through transpilation to C++ (default) and
+directly by LLVM IR (experimental, available via `-emit-cpu-via-llvm`). These
+methods have somewhat different limitations.
+
+It is possible to JIT-execute Slang compute shaders on CPUs. JIT execution
+is only supported through the Slang API. It is available with both the C++ and
+LLVM IR compilation paths, see the examples for how to do this: [C++](https://github.com/shader-slang/slang/tree/master/examples/cpu-hello-world), [LLVM IR](https://github.com/shader-slang/slang/tree/master/examples/cpu-shader-llvm).
+
+Ahead-of-time compilation is available through both the Slang API and the
+`slangc` compiler, although the latter is recommended for that purpose as it is
+easier to integrate into a build system.
+
+### Host-mode execution
+
+In addition to compute shaders, the CPU targets support a unique execution
+model: the "host" mode. This is not a shader stage, instead producing a regular
+CPU program with no shader entry points:
+
+```slang
+export __extern_cpp int main(int argc, NativeString* argv)
+{
+    printf("Hello, world!\n");
+    return 0;
+}
+```
+
+`__extern_cpp` prevents name mangling, making the symbol name match what it
+would be in C. The `executable` and `host-object-code` targets enable the host
+mode. `executable` requires the presence of a `main` entry point. The
+`host-object-code` does not require a `main` function and can therefore be used
+to compile a CPU-side library with Slang.
+
+## Interoperation with C libraries / C FFI
+
+C libraries can be used from Slang. One must first write Slang bindings for
+the C functions. As an example, here's a brief excerpt of bindings for the
+Vulkan API:
+
+```slang
+public enum VkResult: int {
+    SUCCESS = 0,
+    NOT_READY = 1,
+    TIMEOUT = 2
+    // ... rest of the error codes
+};
+
+public struct VkDevice_T;
+public typealias VkDevice = Ptr<VkDevice_T>;
+
+public struct VkSemaphore_T;
+public typealias VkSemaphore = Ptr<VkSemaphore_T>;
+
+__extern_cpp VkResult vkGetSemaphoreCounterValue(VkDevice device, VkSemaphore semaphore, Ptr<uint64_t> pValue);
+```
+
+With this, one can now call `vkGetSemaphoreCounterValue` from Slang code. Now,
+one must link the Vulkan library.
+
+When going through the C++ emitter with `slangc -target executable`, one can
+pass the list of linked libraries to the downstream compiler using
+`-Xgenericcpp`, e.g., `-Xgenericcpp -lVulkan`.
+
+With the LLVM emitter, it is recommended to use `-target host-object-code` to
+produce an object file (`.o`/`.obj`) and use an external linker to produce the
+executable / library. Dependencies can then be linked using that linker, just as
+one would for C code. Note that the C standard library is required, so it is
+easiest to use a C compiler as a linker:
+
+```
+slangc -target host-object-code -emit-cpu-via-llvm myslangcode.slang -o myslangcode.o
+clang myslangcode.o -o myslangexecutable -lVulkan
+```
+
+## Memory allocation
+
+The core module offers two built-in memory allocators on CPU targets,
+`SystemHeapAllocator` and `StackFrameAllocator`.
+
+`SystemHeapAllocator` performs allocations on the heap, providing functionality
+roughly analogous to `malloc` and `free` in C. Allocations must be manually
+released by the user; there is no automatic garbage collection for them.
+
+```slang
+// A do-catch block is required for error handling as the heap allocation may
+// fail when running out of memory.
+do
+{
+    int* integerArray = try SystemHeapAllocator.allocate<int>(10);
+
+    // Deallocates the integer array when exiting the scope
+    defer SystemHeapAllocator.free(integerArray);
+
+    // ... do something with integerArray
+
+    // Expand integer array to fit more data. The previous array length is
+    // provided so that the previous data can be retained.
+    integerArray = try SystemHeapAllocator.reallocate<int>(integerArray, 10, 20);
+
+    // ... do something else with integerArray
+}
+catch (err: MemoryAllocationError)
+{
+    printf("Failed to allocate memory!\n");
+}
+```
+
+Additionally, `Ptr<void> alignedAllocate(size_t bytes, uint alignment)` and
+`void alignedFree(Ptr<void> ptr)` are provided so that allocations with large
+alignments (e.g. page-aligned) can be made.
+
+`StackFrameAllocator` performs allocations on the function's stack frame. This
+means that the allocated memory is automatically released when the function
+returns or throws an error. Note that there usually is a very limited amount
+of stack memory; it should not be used for long arrays. Exceeding the amount
+of available stack memory causes the infamous "stack overflow" error.
+
+```slang
+// If possible, it is best to put stack allocations at the beginning of the
+// function before any branching control flow. This enables better analysis in
+// LLVM, resulting in better optimization.
+int* integerArray = StackFrameAllocator.allocate<int>(10);
+
+// ... do something with integerArray
+
+// No need to free the array; it will be automatically freed when returning from
+// the function that allocated it.
+```
+
+Note that as Slang does not allow taking pointers to local variables, you can
+use `StackFrameAllocator` to allocate data on the stack to achieve the same end
+result. `StackFrameAllocator` does not support `alignedAllocate` and throws an
+error every time it is called.

--- a/docs/user-guide/a2-target-specific-features.md
+++ b/docs/user-guide/a2-target-specific-features.md
@@ -12,6 +12,7 @@ In this chapter:
 2. [Metal target specific](./a2-02-metal-target-specific.md)
 3. [WGSL target specific](./a2-03-wgsl-target-specific.md)
 4. [GLSL target specific](./a2-04-glsl-target-specific.md)
+5. [CPU target specific](./a2-05-cpu-target-specific.md)
 
 <!-- RTD-TOC-START
 ```{toctree}
@@ -22,5 +23,6 @@ SPIR-V target specific <a2-01-spirv-target-specific>
 Metal target specific <a2-02-metal-target-specific>
 WGSL target specific <a2-03-wgsl-target-specific>
 GLSL target specific <a2-04-glsl-target-specific>
+CPU target specific <a2-05-cpu-target-specific>
 ```
 RTD-TOC-END -->

--- a/prelude/slang-cuda-prelude.h
+++ b/prelude/slang-cuda-prelude.h
@@ -2603,6 +2603,19 @@ SLANG_FORCE_INLINE SLANG_CUDA_CALL uintptr_t UPTR_max(uintptr_t a, uintptr_t b)
     return a > b ? a : b;
 }
 
+// ----------------------------- Allocation -----------------------------------------
+
+SLANG_FORCE_INLINE SLANG_CUDA_CALL void* __slang_cuda_realloc(void* oldPtr, size_t oldBytes, size_t newBytes)
+{
+    void* newPtr = malloc(newBytes);
+    if (!newPtr)
+        return nullptr;
+    if (oldPtr && oldBytes)
+        memcpy(newPtr, oldPtr, oldBytes < newBytes ? oldBytes : newBytes);
+    free(oldPtr);
+    return newPtr;
+}
+
 // ----------------------------- ResourceType -----------------------------------------
 
 

--- a/prelude/slang-llvm.h
+++ b/prelude/slang-llvm.h
@@ -22,6 +22,12 @@ extern "C" void assertFailure(const char* msg);
 #endif // SLANG_PRELUDE_ENABLE_ASSERT
 #endif
 
+#define alloca(size) __builtin_alloca(size)
+
+extern "C" void* malloc(__SIZE_TYPE__ size);
+extern "C" void* realloc(void* ptr, __SIZE_TYPE__ size);
+extern "C" void free(void* ptr);
+
 /*
 Taken from stddef.h
 */

--- a/source/core/slang-allocator.h
+++ b/source/core/slang-allocator.h
@@ -17,11 +17,26 @@ inline void* alignedAllocate(size_t size, size_t alignment)
 #if SLANG_WINDOWS_FAMILY
     return _aligned_malloc(size, alignment);
 #elif defined(__CYGWIN__)
-    return aligned_alloc(alignment, size);
+    // On POSIX, aligned_alloc & posix_memalign require a minimum alignment of
+    // sizeof(void*). malloc is required to have a minimum alignment of
+    // alignof(max_align_t) >= sizeof(void*), so we can just use malloc if
+    // the requested alignment is low enough.
+    if (alignment <= alignof(max_align_t))
+        return malloc(size);
+    else
+    {
+        size_t roundedSize = (size + alignment - 1) & ~(alignment - 1);
+        return aligned_alloc(alignment, roundedSize);
+    }
 #else
-    void* rs = nullptr;
-    int succ = posix_memalign(&rs, alignment, size);
-    return (succ == 0) ? rs : nullptr;
+    if (alignment <= alignof(max_align_t))
+        return malloc(size);
+    else
+    {
+        void* rs = nullptr;
+        int succ = posix_memalign(&rs, alignment, size);
+        return (succ == 0) ? rs : nullptr;
+    }
 #endif
 }
 

--- a/source/slang-llvm/slang-llvm-builder.cpp
+++ b/source/slang-llvm/slang-llvm-builder.cpp
@@ -148,7 +148,10 @@ class LLVMBuilder : public ComBaseObject, public ILLVMBuilder
     // externally provided.
     enum class ExternalFunc
     {
-        Printf
+        Printf,
+        Malloc,
+        Realloc,
+        Free
         // TODO: Texture sampling, RT functions?
     };
     // Map of external builtins. These are only forward-declared in the emitted
@@ -236,6 +239,7 @@ public:
     SLANG_NO_THROW void SLANG_MCALL endFunction(LLVMInst* func) override;
 
     SLANG_NO_THROW LLVMInst* SLANG_MCALL emitAlloca(int64_t size, int64_t alignment) override;
+    SLANG_NO_THROW LLVMInst* SLANG_MCALL emitAlloca(LLVMInst* size, int64_t alignment) override;
     SLANG_NO_THROW LLVMInst* SLANG_MCALL
     emitGetElementPtr(LLVMInst* ptr, int64_t stride, LLVMInst* index) override;
     SLANG_NO_THROW LLVMInst* SLANG_MCALL
@@ -779,11 +783,53 @@ llvm::Function* LLVMBuilder::getExternalBuiltin(ExternalFunc extFunc)
     switch (extFunc)
     {
     case ExternalFunc::Printf:
-        func = emitDecl("printf", llvmBuilder->getInt32Ty(), {llvmBuilder->getPtrTy()}, true);
-        llvm::AttrBuilder attrs(*llvmContext);
-        attrs.addCapturesAttr(llvm::CaptureInfo::none());
-        attrs.addAttribute(llvm::Attribute::NoAlias);
-        func->getArg(0)->addAttrs(attrs);
+        {
+            func = emitDecl("printf", llvmBuilder->getInt32Ty(), {llvmBuilder->getPtrTy()}, true);
+            llvm::AttrBuilder attrs(*llvmContext);
+            attrs.addCapturesAttr(llvm::CaptureInfo::none());
+            attrs.addAttribute(llvm::Attribute::NoAlias);
+            func->getArg(0)->addAttrs(attrs);
+        }
+        break;
+    case ExternalFunc::Malloc:
+        {
+            func = emitDecl(
+                "malloc",
+                llvmBuilder->getPtrTy(),
+                {llvmBuilder->getIntPtrTy(targetDataLayout)},
+                false);
+            func->getArg(0)->addAttr(llvm::Attribute::NoUndef);
+            func->addRetAttr(llvm::Attribute::NoAlias);
+            func->addRetAttr(llvm::Attribute::NoUndef);
+        }
+        break;
+    case ExternalFunc::Realloc:
+        {
+            func = emitDecl(
+                "realloc",
+                llvmBuilder->getPtrTy(),
+                {llvmBuilder->getPtrTy(), llvmBuilder->getIntPtrTy(targetDataLayout)},
+                false);
+            llvm::AttrBuilder attrs(*llvmContext);
+            attrs.addCapturesAttr(llvm::CaptureInfo::none());
+            attrs.addAttribute(llvm::Attribute::NoUndef);
+            attrs.addAttribute(llvm::Attribute::AllocatedPointer);
+            func->getArg(0)->addAttrs(attrs);
+            func->getArg(1)->addAttr(llvm::Attribute::NoUndef);
+
+            func->addRetAttr(llvm::Attribute::NoAlias);
+            func->addRetAttr(llvm::Attribute::NoUndef);
+        }
+        break;
+    case ExternalFunc::Free:
+        {
+            func = emitDecl("free", llvmBuilder->getVoidTy(), {llvmBuilder->getPtrTy()}, false);
+            llvm::AttrBuilder attrs(*llvmContext);
+            attrs.addCapturesAttr(llvm::CaptureInfo::none());
+            attrs.addAttribute(llvm::Attribute::AllocatedPointer);
+            attrs.addAttribute(llvm::Attribute::NoUndef);
+            func->getArg(0)->addAttrs(attrs);
+        }
         break;
     }
 
@@ -1059,6 +1105,12 @@ LLVMInst* LLVMBuilder::emitAlloca(int64_t size, int64_t alignment)
         0,
         size > int64_t(INT32_MAX) ? llvmBuilder->getInt64(size) : llvmBuilder->getInt32(size),
         llvm::Align(alignment)));
+}
+
+LLVMInst* LLVMBuilder::emitAlloca(LLVMInst* size, int64_t alignment)
+{
+    return llvmBuilder->Insert(new llvm::AllocaInst(
+        byteType, 0, size, llvm::Align(alignment)));
 }
 
 LLVMInst* LLVMBuilder::emitGetElementPtr(LLVMInst* ptr, int64_t stride, LLVMInst* index)
@@ -1935,9 +1987,26 @@ LLVMInst* LLVMBuilder::emitInlineIRFunction(LLVMInst* func, CharSlice content)
     llvmFunc->setLinkage(llvm::Function::LinkageTypes::ExternalLinkage);
 
     std::string funcName = llvmFunc->getName().str();
+    std::string contentStr = std::string(content.data, content.count);
 
     std::string functionIR;
     llvm::raw_string_ostream expanded(functionIR);
+
+    // Check if the inline contents reference some external builtin that we
+    // need to forward-declare.
+    auto checkBuiltin = [&](const char* name, ExternalFunc id)
+    {
+        if (contentStr.find(name) != std::string::npos)
+        {
+            llvm::Function* func = getExternalBuiltin(id);
+            func->print(expanded, nullptr);
+        }
+    };
+
+    checkBuiltin("@printf(", ExternalFunc::Printf);
+    checkBuiltin("@malloc(", ExternalFunc::Malloc);
+    checkBuiltin("@realloc(", ExternalFunc::Realloc);
+    checkBuiltin("@free(", ExternalFunc::Free);
 
     // This is a bit of a hack. We add a block to the function so that
     // it gets printed as a definition instead of a declaration, and then
@@ -1949,7 +2018,7 @@ LLVMInst* LLVMBuilder::emitInlineIRFunction(LLVMInst* func, CharSlice content)
     while (functionIR.size() > 0 && functionIR.back() != '{')
         functionIR.pop_back();
 
-    expanded << "\nentry:\n" << std::string(content.data, content.count) << "\n}\n";
+    expanded << "\nentry:\n" << contentStr << "\n}\n";
 
     emitGlobalLLVMIR(functionIR);
 
@@ -2348,7 +2417,7 @@ SlangResult LLVMBuilder::generateJITLibrary(IArtifact** outArtifact)
 
 } // namespace slang_llvm
 
-extern "C" SLANG_DLL_EXPORT SlangResult createLLVMBuilder_V2(
+extern "C" SLANG_DLL_EXPORT SlangResult createLLVMBuilder_V3(
     const SlangUUID& intfGuid,
     Slang::ILLVMBuilder** out,
     Slang::LLVMBuilderOptions options,

--- a/source/slang-llvm/slang-llvm-builder.h
+++ b/source/slang-llvm/slang-llvm-builder.h
@@ -190,6 +190,7 @@ public:
     // Instructions
     //==========================================================================
     virtual SLANG_NO_THROW LLVMInst* SLANG_MCALL emitAlloca(int64_t size, int64_t alignment) = 0;
+    virtual SLANG_NO_THROW LLVMInst* SLANG_MCALL emitAlloca(LLVMInst* size, int64_t alignment) = 0;
     virtual SLANG_NO_THROW LLVMInst* SLANG_MCALL
     emitGetElementPtr(LLVMInst* ptr, int64_t stride, LLVMInst* index) = 0;
     virtual SLANG_NO_THROW LLVMInst* SLANG_MCALL

--- a/source/slang-llvm/slang-llvm.cpp
+++ b/source/slang-llvm/slang-llvm.cpp
@@ -436,7 +436,10 @@ static uint64_t __stdcall _aulldiv(uint64_t a, uint64_t b)
     x(memcpy, memcpy, void*, (void*, const void*, size_t)) \
     x(memmove, memmove, void*, (void*, const void*, size_t)) \
     x(memcmp, memcmp, int, (const void*, const void*, size_t)) \
-    x(memset, memset, void*, (void*, int, size_t)) 
+    x(memset, memset, void*, (void*, int, size_t)) \
+    x(malloc, malloc, void*, (size_t)) \
+    x(free, free, void, (void*)) \
+    x(realloc, realloc, void*, (void*, size_t))
 
 #if SLANG_OSX
 #   define SLANG_PLATFORM_FUNCS(x) \

--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -1614,6 +1614,413 @@ __intrinsic_op($(kIROp_Eql))
 bool operator ==($(fullPtrType) p1, $(fullPtrType) p2);
 
 //@public:
+/// Describes the kinds of errors thrown by `IAllocator` when a memory
+/// allocation fails.
+public enum MemoryAllocationError
+{
+    /// An allocation of the given size is not possible. Note that this does not
+    /// mean that a later allocation may not succeed - a gigabyte-sized
+    /// allocation can cause this error while a later megabyte-sized allocation
+    /// can still succeed.
+    OutOfMemory = 0,
+
+    /// The required alignment is not achievable with this allocator. Note that
+    /// there is no such thing as `AlignmentIsTooSmall` - the allocator can
+    /// always return addresses with a larger alignment than was requested.
+    AlignmentIsTooLarge = 1
+}
+
+/// Defines the interface for memory allocators.
+///
+/// As an implementor of a memory allocator, the minimum you need to implement
+/// is `allocate`, everything else has a technically valid default
+/// implementation. It's also good to implement `free` or `close` to allow
+/// the user some way of deallocating memory. The default implementations assume
+/// that `nullptr` is a valid pointer, which may or may not be true depending on
+/// your address space and allocator.
+///
+/// @param addrSpace The address space of pointers which the allocator operates with
+interface IAllocator<AddressSpace addrSpace>
+{
+    /// Allocates a segment of memory which is large enough to store `T[count]`
+    /// in the given layout L.
+    /// @param T The type of data to allocate
+    /// @param L (Optional) An explicit data layout to use for the resulting
+    /// pointer.
+    /// @param count Number of `T` to allocate.
+    /// @return pointer to at least enough memory to store `T[count]`
+    /// @throws MemoryAllocationError
+    ///
+    /// @remarks It is undefined behavior if count * sizeof(T, L) > size_t.maxValue.
+    ///
+    /// @remarks It is valid for `count` to be zero, but there is no guarantee
+    /// that the returned pointer would be unique.
+    [mutating]
+    Ptr<T, Access.ReadWrite, addrSpace, L>
+        allocate<T, L:IBufferDataLayout = DefaultDataLayout>(size_t count) throws MemoryAllocationError;
+
+    /// Allocates a segment of memory with at least the given alignment. The
+    /// resulting pointer must only be freed using `alignedFree()`, not the
+    /// normal `free()`, and it also must not be used with `reallocate()`.
+    ///
+    /// @param bytes Number of bytes to allocate.
+    /// @param alignment The desired alignment for the returned pointer.
+    /// @return pointer to at least enough memory to store the given number of
+    /// bytes that is also aligned as requested.
+    /// @throws MemoryAllocationError Can run out of memory or reject given
+    /// alignment depending on allocator.
+    ///
+    /// @remarks the regular `allocate()` already returns pointers aligned
+    /// correctly for `T`, so this function only needs to be used in very
+    /// specific circumstances where e.g. cache line or page alignment is
+    /// required.
+    ///
+    /// @remarks It is valid for `bytes` to be zero, but there is no guarantee
+    /// that the returned pointer would be unique.
+    [mutating]
+    Ptr<void, Access.ReadWrite, addrSpace>
+        alignedAllocate(size_t bytes, uint alignment) throws MemoryAllocationError
+    {
+        size_t allocCount = try __alignedAllocPtrLength<addrSpace>(bytes, alignment);
+        let unalignedPtr = try allocate<Ptr<void, Access.ReadWrite, addrSpace>, DefaultDataLayout>(allocCount);
+        return __finalizeAlignedAlloc<addrSpace>(
+            reinterpret<Ptr<void, Access.ReadWrite, addrSpace>>(unalignedPtr),
+            alignment);
+    }
+
+    /// Returns a pointer to a memory allocation that is large enough to store
+    /// `T[newCount]` and is initialized with the first
+    /// `min(oldCount, newCount)` entries from `oldPtr`.
+    ///
+    /// `oldPtr` must have been allocated by this allocator instance using
+    /// `allocate<T>()` or `reallocate<T>()`, where the `oldCount` parameter is
+    /// smaller than or equal to `count` or `newCount` used to allocate the
+    /// memory. It is undefined behavior to call this function with a pointer
+    /// that was not allocated with `allocate` or `reallocate`, even if it is
+    /// nullptr.
+    ///
+    /// The returned pointer is either `oldPtr` if the existing allocation was
+    /// extended, or a new pointer to a new allocation. If `oldPtr` was replaced
+    /// by a new pointer, the old one is automatically freed.
+    ///
+    /// @param oldPtr Pointer to an allocation that is either to be extended
+    /// or reallocated.
+    /// @param oldCount The count of `T` instances available via `oldPtr`
+    /// @param newCount The number of `T` to allocate.
+    /// @return pointer to at least enough memory to store `T[newCount]`,
+    /// initialized with contents from `oldPtr`.
+    /// @throws MemoryAllocationError
+    /// @remarks It is undefined behavior if newCount * sizeof(T, L) > size_t.maxValue.
+    ///
+    /// @remarks It is valid for `newCount` to be zero, but there is no
+    /// guarantee that the returned pointer would be unique.
+    [mutating]
+    Ptr<T, Access.ReadWrite, addrSpace, L> reallocate<T, L:IBufferDataLayout = DefaultDataLayout>(
+        Ptr<T, Access.ReadWrite, addrSpace, L> oldPtr,
+        size_t oldCount,
+        size_t newCount
+    ) throws MemoryAllocationError {
+        let newPtr = try allocate<T, L>(newCount);
+        size_t copyCount = min(oldCount, newCount);
+        for (size_t i = 0; i < copyCount; ++i)
+            newPtr[i] = oldPtr[i];
+        free(oldPtr);
+        return newPtr;
+    }
+
+    /// This function may free the given pointer. The behavior is undefined if
+    /// the pointer was not acquired via `allocate<T>()` or `reallocate<T>()` of
+    /// the same allocator instance, and if the type of the given pointer has
+    /// different alignment than it was allocated with. It is undefined behavior
+    /// to call this function with a pointer that was not allocated with
+    /// `allocate` or `reallocate`, even if it is nullptr.
+    ///
+    /// After this call, you must not dereference the pointer.
+    ///
+    /// @param data A pointer to an allocation that should be released.
+    ///
+    /// @remarks It is possible that an allocator does not support this
+    /// operation, in which case the behavior will be a no-op.
+    [mutating]
+    void free<T, L:IBufferDataLayout = DefaultDataLayout>(Ptr<T, Access.ReadWrite, addrSpace, L> data)
+    {
+    }
+
+    /// This function may free the given pointer, which must have been
+    /// allocated with `alignedAllocate()`. It is undefined behavior if the
+    /// pointer was not allocated with that function, including nullptr.
+    ///
+    /// @param data A pointer to an allocation that should be released.
+    [mutating]
+    void alignedFree(Ptr<void, Access.ReadWrite, addrSpace> data)
+    {
+        let ptrData = reinterpret<Ptr<Ptr<void, Access.ReadWrite, addrSpace>, Access.ReadWrite, addrSpace>>(data);
+        let prevPtr = reinterpret<Ptr<Ptr<void, Access.ReadWrite, addrSpace>, Access.ReadWrite, addrSpace>>(ptrData[-1]);
+        free<Ptr<void, Access.ReadWrite, addrSpace>, DefaultDataLayout>(prevPtr);
+    }
+
+    /// This function may free all prior allocations made through this
+    /// allocator. After calling `close()`, you must never dereference pointers
+    /// allocated prior to the call.
+    ///
+    /// @remarks It is possible that an allocator does not support this
+    /// operation, in which case the behavior will be a no-op.
+    [mutating]
+    void close()
+    {
+        // default no-op impl
+    }
+}
+
+//@hidden:
+
+[ForceInline]
+size_t __strideOf<T, L:IBufferDataLayout>()
+{
+    return sizeof(T[2], L) - sizeof(T, L);
+}
+
+[ForceInline]
+[require(cpp_cuda_llvm)]
+internal size_t __getArrayMemoryAllocSize<T, L:IBufferDataLayout>(size_t count)
+    throws MemoryAllocationError
+{
+    size_t stride = __strideOf<T, L>();
+    if (stride == 0)
+        return 0;
+
+    // Can't possibly have enough memory if the array size would overflow size_t.
+    if (count > size_t.maxValue / stride)
+        throw MemoryAllocationError.OutOfMemory;
+
+    return count * stride;
+}
+
+// Used as part of the default implementation of alignedAllocate.
+size_t __alignedAllocPtrLength<AddressSpace addrSpace>(size_t bytes, uint alignment)
+    throws MemoryAllocationError
+{
+    size_t ptrSize = sizeof(Ptr<void, Access.ReadWrite, addrSpace>);
+    size_t ptrAlign = alignof(Ptr<void, Access.ReadWrite, addrSpace>);
+    size_t allocSize = bytes + ptrSize;
+
+    // Worst case allocSize = bytes + ptrSize + alignment + ptrSize - 1
+    if (bytes > size_t.maxValue - 2 * ptrSize - alignment + 1)
+        throw MemoryAllocationError.OutOfMemory;
+
+    if (alignment > ptrAlign)
+    {
+        // There's a chance we may have to realign the returned pointer,
+        // so we'll need extra space for that.
+        allocSize += alignment;
+    }
+    // If this were an array of pointers, determine the count.
+    return (allocSize + ptrSize - 1) / ptrSize;
+}
+
+// Used as part of the default implementation of alignedAllocate.
+Ptr<void, Access.ReadWrite, addrSpace> __finalizeAlignedAlloc<AddressSpace addrSpace>(
+    Ptr<void, Access.ReadWrite, addrSpace> unalignedPtr,
+    uint alignment)
+{
+    size_t ptrSize = sizeof(Ptr<void, Access.ReadWrite, addrSpace>);
+    size_t ptrAlign = alignof(Ptr<void, Access.ReadWrite, addrSpace>);
+
+    // Leave room to store original address in [-1].
+    uintptr_t alignedPtr = reinterpret<uintptr_t>(unalignedPtr)+ptrSize;
+
+    // If we need special alignment, do that!
+    if (alignment > ptrAlign)
+        alignedPtr = (alignedPtr + alignment-1) & (~uintptr_t(alignment-1));
+
+    let alignedPtrPtr = reinterpret<Ptr<Ptr<void, Access.ReadWrite, addrSpace>, Access.ReadWrite, addrSpace>>(alignedPtr);
+    alignedPtrPtr[-1] = reinterpret<Ptr<void, Access.ReadWrite, addrSpace>>(unalignedPtr);
+
+    return reinterpret<Ptr<void, Access.ReadWrite, addrSpace>>(alignedPtrPtr);
+}
+
+[ForceInline]
+[require(cpp_cuda_llvm)]
+Ptr<void> __cpu_malloc(size_t bytes)
+{
+    __target_switch
+    {
+    case cpp:
+    case cuda:
+        __intrinsic_asm "malloc($0)";
+    case llvm:
+        __intrinsic_asm "%result = call ptr @malloc($0)";
+    }
+}
+
+[ForceInline]
+[require(cpp_cuda_llvm)]
+Ptr<void> __cpu_realloc(Ptr<void> oldPtr, size_t oldBytes, size_t bytes)
+{
+    __target_switch
+    {
+    case cpp:
+        __intrinsic_asm "realloc($0, $2)";
+    case cuda:
+        __intrinsic_asm "__slang_cuda_realloc($0, $1, $2)";
+    case llvm:
+        __intrinsic_asm "%result = call ptr @realloc($0, $2)";
+    }
+}
+
+[ForceInline]
+[require(cpp_cuda_llvm)]
+void __cpu_free(Ptr<void> ptr)
+{
+    __target_switch
+    {
+    case cpp:
+    case cuda:
+        __intrinsic_asm "free($0)";
+    case llvm:
+        __intrinsic_asm "call void @free($0)";
+    }
+}
+
+//@public:
+
+/// This allocator allocates memory in the global memory heap. It provides
+/// functionality that is roughly equivalent to the `malloc`/`free` of C.
+///
+/// @remarks You do not need to form an instance of the allocator to use it, you
+/// can simply call `SystemHeapAllocator.allocate<T>(count)`.
+[require(cpp_cuda_llvm)]
+public struct SystemHeapAllocator: IAllocator<AddressSpace.Device>
+{
+    static LayoutPtr<T, L> allocate<T, L:IBufferDataLayout = DefaultDataLayout>(size_t count = 1) throws MemoryAllocationError
+    {
+        Ptr<void> allocation;
+
+        size_t allocSize = try __getArrayMemoryAllocSize<T, L>(count);
+
+        if (alignof(T, L) > alignof(Ptr<void>))
+        {
+            // malloc is only guaranteed to be aligned up to the maximum scalar
+            // size, so if our data layout requires a larger alignment for e.g.
+            // a vector, we have to do that ourselves.
+            allocation = try alignedAllocate(allocSize, alignof(T, L));
+        }
+        else
+        {
+            allocation = __cpu_malloc(allocSize);
+            if (allocation == nullptr && count != 0)
+                throw MemoryAllocationError.OutOfMemory;
+        }
+        return reinterpret<LayoutPtr<T, L>>(allocation);
+    }
+
+    static override Ptr<void> alignedAllocate(size_t bytes, uint alignment) throws MemoryAllocationError
+    {
+        size_t allocCount = try __alignedAllocPtrLength<AddressSpace.Device>(bytes, alignment);
+        Ptr<void> allocation = __cpu_malloc(allocCount * sizeof(Ptr<void>));
+        if (allocation == nullptr && allocCount != 0)
+            throw MemoryAllocationError.OutOfMemory;
+        return __finalizeAlignedAlloc(allocation, alignment);
+    }
+
+    static override LayoutPtr<T, L> reallocate<T, L:IBufferDataLayout = DefaultDataLayout>(
+        LayoutPtr<T, L> oldPtr,
+        size_t oldCount,
+        size_t newCount
+    ) throws MemoryAllocationError {
+        if (oldPtr == nullptr)
+            return try allocate<T, L>(newCount);
+
+        if (alignof(T, L) > alignof(Ptr<void>))
+        {
+            let newPtr = try allocate<T, L>(newCount);
+            size_t copyCount = oldCount < newCount ? oldCount : newCount;
+            for (size_t i = 0; i < copyCount; ++i)
+                newPtr[i] = oldPtr[i];
+            free(oldPtr);
+            return newPtr;
+        }
+        else
+        {
+            size_t oldAllocSize = try __getArrayMemoryAllocSize<T, L>(oldCount);
+            size_t newAllocSize = try __getArrayMemoryAllocSize<T, L>(newCount);
+            let newPtr = __cpu_realloc(Ptr<void>(oldPtr), oldAllocSize, newAllocSize);
+            if (newPtr == nullptr && newCount != 0)
+                throw MemoryAllocationError.OutOfMemory;
+            return reinterpret<LayoutPtr<T, L>>(newPtr);
+        }
+    }
+
+    static override void free<T, L:IBufferDataLayout = DefaultDataLayout>(LayoutPtr<T, L> data)
+    {
+        if (alignof(T, L) > alignof(Ptr<void>))
+            alignedFree(reinterpret<Ptr<void>>(data));
+        else
+            __cpu_free(reinterpret<Ptr<void>>(data));
+    }
+
+    static override void alignedFree(Ptr<void> data)
+    {
+        if (data != nullptr)
+            __cpu_free(reinterpret<Ptr<Ptr<void>>>(data)[-1]);
+    }
+}
+
+/// This allocator allocates memory in the calling function's stack frame.
+/// It is effectively equivalent to `alloca()` in C and comes with the same
+/// caveats: Unnecessary use can hinder optimization and excessively large
+/// or looped allocations can easily cause stack overflows.
+///
+/// Ideally, you should only use it when you absolutely need a pointer to a
+/// stack-allocated object, and call it outside of loops.
+///
+/// @remarks you should not form an instance of the allocator to use it, you
+/// can simply call `StackFrameAllocator.allocate<T>(count)`.
+///
+/// @remarks all allocated memory is released automatically when the calling
+/// function returns, so you don't need to manually free it in any way, but you
+/// do need to avoid leaking the pointer outside of the function.
+[require(cpp_llvm)]
+[require(cuda, cuda_sm_6_0)]
+public struct StackFrameAllocator: IAllocator<AddressSpace.Device>
+{
+    [ForceInline]
+    __intrinsic_op($(kIROp_Alloca))
+    static LayoutPtr<T, L> allocate<T, L:IBufferDataLayout = DefaultDataLayout>(size_t count = 1);
+
+    [ForceInline]
+    static override LayoutPtr<T, L> reallocate<T, L:IBufferDataLayout = DefaultDataLayout>(
+        LayoutPtr<T, L> oldPtr,
+        size_t oldCount,
+        size_t newCount
+    ){
+        // No shrinking supported ever anyway, so we may as well return the old
+        // pointer.
+        if (newCount <= oldCount)
+            return oldPtr;
+
+        let newPtr = allocate<T, L>(newCount);
+        size_t copyCount = min(oldCount, newCount);
+        for (size_t i = 0; i < copyCount; ++i)
+            newPtr[i] = oldPtr[i];
+        return newPtr;
+    }
+
+    static override Ptr<void> alignedAllocate(size_t bytes, uint alignment) throws MemoryAllocationError
+    {
+        // Arbitrary-alignment allocas aren't really supported by C++, Cuda or
+        // LLVM IR (alignment needs to be compile-time for LLVM IR).
+        throw MemoryAllocationError.AlignmentIsTooLarge;
+    }
+
+    override void alignedFree(Ptr<void> data)
+    {
+        // Overridden to ensure that this is also a NOP. Stack allocations don't
+        // need manual deallocation.
+    }
+}
+
+//@public:
 extension bool : IRangedValue
 {
     __generic<$(ptrTypeParameterList)>

--- a/source/slang/slang-emit-cpp.cpp
+++ b/source/slang/slang-emit-cpp.cpp
@@ -1731,9 +1731,16 @@ bool CPPSourceEmitter::tryEmitInstExprImpl(IRInst* inst, const EmitOpInfo& inOut
         }
     case kIROp_Alloca:
         {
+            auto ptrType = cast<IRPtrType>(inst->getDataType());
+
+            m_writer->emit("(");
+            emitType(ptrType);
+            m_writer->emit(")");
             m_writer->emit("alloca(");
-            emitOperand(inst->getOperand(0), EmitOpInfo::get(EmitOp::Postfix));
-            m_writer->emit("->typeSize)");
+            emitOperand(inst->getOperand(0), getInfo(EmitOp::General));
+            m_writer->emit(" * sizeof(");
+            emitType(ptrType->getValueType());
+            m_writer->emit("))");
             return true;
         }
     case kIROp_BitCast:

--- a/source/slang/slang-emit-cuda.cpp
+++ b/source/slang/slang-emit-cuda.cpp
@@ -1377,6 +1377,20 @@ bool CUDASourceEmitter::tryEmitInstExprImpl(IRInst* inst, const EmitOpInfo& inOu
             m_writer->emit(").data)");
             return true;
         }
+    case kIROp_Alloca:
+        {
+            auto ptrType = cast<IRPtrType>(inst->getDataType());
+
+            m_writer->emit("(");
+            emitType(ptrType);
+            m_writer->emit(")");
+            m_writer->emit("alloca(");
+            emitOperand(inst->getOperand(0), getInfo(EmitOp::General));
+            m_writer->emit(" * sizeof(");
+            emitType(ptrType->getValueType());
+            m_writer->emit("))");
+            return true;
+        }
     default:
         break;
     }

--- a/source/slang/slang-emit-llvm.cpp
+++ b/source/slang/slang-emit-llvm.cpp
@@ -688,13 +688,13 @@ struct LLVMEmitter
             return SLANG_FAIL;
         }
 
-        using BuilderFuncV2 = SlangResult (*)(
+        using BuilderFuncV3 = SlangResult (*)(
             const SlangUUID& intfGuid,
             Slang::ILLVMBuilder** out,
             Slang::LLVMBuilderOptions options,
             Slang::IArtifact** outErrorArtifact);
 
-        auto builderFunc = (BuilderFuncV2)library->findFuncByName("createLLVMBuilder_V2");
+        auto builderFunc = (BuilderFuncV3)library->findFuncByName("createLLVMBuilder_V3");
         if (!builderFunc)
             return SLANG_FAIL;
 
@@ -1108,10 +1108,22 @@ struct LLVMEmitter
     LLVMInst* emitArrayGetElementPtr(
         LLVMInst* llvmPtr,
         LLVMInst* indexInst,
+        bool signedIndex,
         IRType* elemType,
         IRTypeLayoutRules* rules)
     {
         IRSizeAndAlignment sizeAndAlignment = types->getSizeAndAlignment(elemType, rules);
+        if (!signedIndex)
+        {
+            // If we have an unsigned index with less bits than a pointer, LLVM
+            // will sign-extend it while we need zero-extension. So we have to
+            // cast manually to avoid that. Note that emitCast just passes
+            // through if the type is already correct.
+            int pointerBits = builder->getPointerSizeInBits();
+            LLVMType* extendedType = builder->getIntType(pointerBits);
+            indexInst = builder->emitCast(indexInst, extendedType, false, false);
+        }
+
         return builder->emitGetElementPtr(llvmPtr, sizeAndAlignment.getStride(), indexInst);
     }
 
@@ -1158,11 +1170,13 @@ struct LLVMEmitter
                     auto dstElemPtr = emitArrayGetElementPtr(
                         dstPtr,
                         builder->getConstantInt(builder->getIntType(32), elem),
+                        false,
                         elemType,
                         dstLayout);
                     auto srcElemPtr = emitArrayGetElementPtr(
                         srcPtr,
                         builder->getConstantInt(builder->getIntType(32), elem),
+                        false,
                         elemType,
                         srcLayout);
                     last = crossLayoutMemCpy(
@@ -1667,6 +1681,7 @@ struct LLVMEmitter
                 LLVMInst* ptr = emitArrayGetElementPtr(
                     llvmInst,
                     builder->getConstantInt(int32Type, aa),
+                    false,
                     op->getDataType(),
                     defaultPointerRules);
                 emitStore(ptr, findValue(op), op->getDataType(), defaultPointerRules);
@@ -1699,6 +1714,7 @@ struct LLVMEmitter
                     LLVMInst* ptr = emitArrayGetElementPtr(
                         llvmInst,
                         builder->getConstantInt(int32Type, i),
+                        false,
                         element->getDataType(),
                         defaultPointerRules);
                     emitStore(ptr, llvmElement, element->getDataType(), defaultPointerRules);
@@ -1831,6 +1847,7 @@ struct LLVMEmitter
                     auto llvmDstElement = emitArrayGetElementPtr(
                         llvmDst,
                         maybeEmitConstant(irElementIndex),
+                        isSigned(irElementIndex),
                         elementType,
                         rules);
                     auto llvmSrcElement =
@@ -1943,6 +1960,7 @@ struct LLVMEmitter
                 llvmInst = emitArrayGetElementPtr(
                     findValue(baseInst),
                     findValue(indexInst),
+                    isSigned(indexInst),
                     baseType,
                     getBufferLayoutRules(baseInst->getDataType()));
             }
@@ -1979,6 +1997,7 @@ struct LLVMEmitter
                 llvmInst = emitArrayGetElementPtr(
                     findValue(baseInst),
                     findValue(indexInst),
+                    isSigned(indexInst),
                     elemType,
                     getBufferLayoutRules(baseInst->getDataType()));
             }
@@ -2011,6 +2030,7 @@ struct LLVMEmitter
                     LLVMInst* ptr = emitArrayGetElementPtr(
                         llvmVal,
                         findValue(indexInst),
+                        isSigned(indexInst),
                         elemType,
                         defaultPointerRules);
                     llvmInst = emitLoad(ptr, elemType, defaultPointerRules);
@@ -2148,6 +2168,39 @@ struct LLVMEmitter
         case kIROp_MakeString:
             // For now, String == NativeString on the LLVM target.
             llvmInst = findValue(inst->getOperand(0));
+            break;
+
+        case kIROp_Alloca:
+            {
+                auto ptrType = cast<IRPtrType>(inst->getDataType());
+                auto count = findValue(inst->getOperand(0));
+
+                IRSizeAndAlignment sizeAndAlignment = types->getSizeAndAlignment(
+                    ptrType->getValueType(),
+                    getBufferLayoutRules(ptrType));
+
+                // Do size computation in size_t:
+                auto intType = builder->getIntType(builder->getPointerSizeInBits());
+                count = builder->emitCast(count, intType, false, false);
+                auto allocSize = builder->getConstantInt(intType, sizeAndAlignment.getStride());
+                allocSize = builder->emitBinaryOp(LLVMBinaryOp::Mul, allocSize, count);
+
+                // This is a runtime alloca, which the user can assume to
+                // _always_ reserve more memory. Hence, we can't always hoist
+                // it into the header block.
+                //
+                // TODO: We _could_ hoist it when it isn't in a loop (no
+                // transitive successor is a transitive predecessor of this
+                // block) AND the count is a constant. Left for future
+                // improvement.
+                //
+                // The TODO isn't a vital, because it mostly helps mem2reg, but
+                // the cases where language users need this feature are when
+                // they explicitly need to get a stack pointer, preventing
+                // mem2reg anyway.
+
+                llvmInst = builder->emitAlloca(allocSize, sizeAndAlignment.alignment);
+            }
             break;
 
         case kIROp_DebugVar:

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -791,14 +791,6 @@ struct IRGetSequentialID : IRInst
     FIDDLE(leafInst())
 };
 
-/// Allocates space from local stack.
-///
-FIDDLE()
-struct IRAlloca : IRInst
-{
-    FIDDLE(leafInst())
-};
-
 /// A non-hoistable inst used to "pin" a global value inside a function body so any insts dependent
 /// on `value` can be emitted as local insts instead of global insts, as required by targets (e.g.
 /// spirv) that doesn't allow the dependent computation in the global scope.
@@ -3625,8 +3617,6 @@ $(type_info.return_type) $(type_info.method_name)(
         IRInst* interfaceMethodVal);
 
     IRInst* emitGetSequentialIDInst(IRInst* rttiObj);
-
-    IRInst* emitAlloca(IRInst* type, IRInst* rttiObjPtr);
 
     IRInst* emitGlobalValueRef(IRInst* globalInst);
 

--- a/source/slang/slang-ir-insts.lua
+++ b/source/slang/slang-ir-insts.lua
@@ -1032,7 +1032,7 @@ local insts = {
 	{ CombinedTextureSamplerGetSampler = { operands = { { "sampler" } } } },
 	{ call = { operands = { { "callee" } } } },
 	{ rtti_object = { struct_name = "RTTIObject" } },
-	{ alloca = { operands = { { "allocSize" } } } },
+	{ alloca = { operands = { { "count" } } } },
 	{ updateElement = { operands = { { "oldValue" }, { "elementValue" } } } },
 	{ detachDerivative = { operands = { { "value" } } } },
 	{ bitfieldExtract = { operands = { { "value" }, { "offset" }, { "count" } } } },

--- a/source/slang/slang-ir-peephole.cpp
+++ b/source/slang/slang-ir-peephole.cpp
@@ -5,6 +5,7 @@
 #include "slang-ir-layout.h"
 #include "slang-ir-sccp.h"
 #include "slang-ir-util.h"
+#include "slang-ir-lower-buffer-element-type.h"
 #include "slang-target-program.h"
 
 namespace Slang
@@ -322,12 +323,18 @@ struct PeepholeContext : InstPassBase
 
                 IRTypeLayoutRules* layoutRules = IRTypeLayoutRules::getNatural();
 
+                IRBuilder builder(module);
+                IRBuilderSourceLocRAII srcLocRAII(&builder, inst->sourceLoc);
+
                 if (inst->getOperandCount() >= 2)
                 {
                     auto layoutOp = inst->getOperand(1)->getOp();
 
+                    IRTypeLayoutRuleName defaultRule = getTypeLayoutRuleNameForBuffer(
+                        targetProgram, builder.getPtrType(baseType));
+
                     auto ruleName =
-                        getTypeLayoutRuleNameFromOp(layoutOp, IRTypeLayoutRuleName::Natural);
+                        getTypeLayoutRuleNameFromOp(layoutOp, defaultRule);
 
                     if (!ruleName.has_value())
                         break;
@@ -385,9 +392,6 @@ struct PeepholeContext : InstPassBase
                     break;
                 if (sizeAlignment.size == IRSizeAndAlignment::kIndeterminateSize)
                     break;
-
-                IRBuilder builder(module);
-                IRBuilderSourceLocRAII srcLocRAII(&builder, inst->sourceLoc);
 
                 builder.setInsertBefore(inst);
                 IRInst* resultVal = nullptr;

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -3788,7 +3788,7 @@ IRInst* IRBuilder::emitLookupInterfaceMethodInst(
 
 IRInst* IRBuilder::emitGetSequentialIDInst(IRInst* rttiObj)
 {
-    auto inst = createInst<IRAlloca>(this, kIROp_GetSequentialID, getUIntType(), rttiObj);
+    auto inst = createInst<IRGetSequentialID>(this, kIROp_GetSequentialID, getUIntType(), rttiObj);
     addInst(inst);
     return inst;
 }
@@ -3808,14 +3808,6 @@ IRInst* IRBuilder::emitBitfieldInsert(
     IRInst* bits)
 {
     auto inst = createInst<IRInst>(this, kIROp_BitfieldInsert, type, base, insert, offset, bits);
-    addInst(inst);
-    return inst;
-}
-
-IRInst* IRBuilder::emitAlloca(IRInst* type, IRInst* rttiObjPtr)
-{
-    auto inst = createInst<IRAlloca>(this, kIROp_Alloca, (IRType*)type, rttiObjPtr);
-
     addInst(inst);
     return inst;
 }

--- a/tests/language-feature/allocator/stack-frame-allocator.slang
+++ b/tests/language-feature/allocator/stack-frame-allocator.slang
@@ -1,0 +1,111 @@
+// The stack frame allocator is only available on the CPU and CUDA targets.
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK): -cuda -compute
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK): -cpu -compute
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK): -llvm -compute
+
+// Unfortunately, there is no way to directly test the data layout
+// functionality - it only changes the size of the allocation in bytes, which
+// the allocators do not actually communicate.
+
+//TEST_INPUT:set outputBuffer = out ubuffer(data=[0 0 0 0 0 0 0 0 0 0 0], stride=4)
+RWStructuredBuffer<int> outputBuffer;
+
+bool isAligned<T>(Ptr<T> aligned, size_t expectedAlignment)
+{
+    return (reinterpret<uintptr_t>(aligned) & (expectedAlignment-1)) == 0;
+}
+
+void alignTest()
+{
+    // The order is intentionally small->high to ensure that naively allocating
+    // the next free pointer would cause misalignment.
+    // CHECK: 1
+    outputBuffer[0] = isAligned(StackFrameAllocator.allocate<uint8_t, DefaultDataLayout>(), 1) ? 1 : 0;
+    // CHECK-NEXT: 1
+    outputBuffer[1] = isAligned(StackFrameAllocator.allocate<uint16_t, DefaultDataLayout>(), 2) ? 1 : 0;
+    // CHECK-NEXT: 1
+    outputBuffer[2] = isAligned(StackFrameAllocator.allocate<uint, DefaultDataLayout>(), 4) ? 1 : 0;
+    // CHECK-NEXT: 1
+    outputBuffer[3] = isAligned(StackFrameAllocator.allocate<uint64_t, DefaultDataLayout>(), 8) ? 1 : 0;
+    // CHECK-NEXT: 1
+    outputBuffer[4] = isAligned(StackFrameAllocator.allocate<float4, DefaultDataLayout>(), 16) ? 1 : 0;
+}
+
+bool loopTest()
+{
+    // We should get a different pointer on each iteration; hoisting the alloca
+    // is not correct behavior here.
+    int* ints = StackFrameAllocator.allocate<int, DefaultDataLayout>(8);
+    for (int i = 0; i < 4; ++i)
+    {
+        int* localInts = StackFrameAllocator.allocate<int, DefaultDataLayout>(8);
+        if (localInts == ints)
+            return false;
+        ints = localInts;
+    }
+    return true;
+}
+
+bool reallocTest<T: __BuiltinIntegerType>()
+{
+    T* ptr = StackFrameAllocator.allocate<T, DefaultDataLayout>(8);
+    for (int i = 0; i < 8; ++i)
+    {
+        ptr[i] = T(10+i);
+    }
+
+    T* rePtr;
+    do
+    {
+        rePtr = StackFrameAllocator.reallocate<T, DefaultDataLayout>(ptr, 8, 16);
+    }
+    catch
+    {
+        return false;
+    }
+    for (int i = 0; i < 8; ++i)
+        if (rePtr[i] != T(10+i))
+            return false;
+
+    do
+    {
+        rePtr = StackFrameAllocator.reallocate<T, DefaultDataLayout>(rePtr, 16, 8);
+    }
+    catch
+    {
+        return false;
+    }
+    for (int i = 0; i < 8; ++i)
+        if (rePtr[i] != T(10+i))
+            return false;
+    return true;
+}
+
+[numthreads(1,1,1)]
+void computeMain()
+{
+    alignTest();
+    // CHECK-NEXT: 1
+    outputBuffer[5] = loopTest() ? 1 : 0;
+
+    // CHECK-NEXT: 1
+    outputBuffer[6] = reallocTest<uint8_t>() ? 1 : 0;
+    // CHECK-NEXT: 1
+    outputBuffer[7] = reallocTest<uint16_t>() ? 1 : 0;
+    // CHECK-NEXT: 1
+    outputBuffer[8] = reallocTest<uint>() ? 1 : 0;
+    // CHECK-NEXT: 1
+    outputBuffer[9] = reallocTest<uint64_t>() ? 1 : 0;
+
+    // CHECK-NEXT: 1
+    do
+    {
+        // Dynamically-aligned allocations aren't supported on the stack.
+        void* ptr = try StackFrameAllocator.alignedAllocate(256, 4);
+        outputBuffer[10] = 0;
+    }
+    catch (err: MemoryAllocationError)
+    {
+        outputBuffer[10] = err == MemoryAllocationError.AlignmentIsTooLarge ? 1 : 2;
+    }
+}

--- a/tests/language-feature/allocator/system-heap-allocator.slang
+++ b/tests/language-feature/allocator/system-heap-allocator.slang
@@ -1,0 +1,151 @@
+// The system heap allocator is only available on the CPU and CUDA targets.
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK): -cuda -compute
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK): -cpu -compute
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK): -llvm -compute
+
+// Unfortunately, there is no way to directly test the data layout
+// functionality - it only changes the size of the allocation in bytes, which
+// the allocators do not actually communicate.
+
+//TEST_INPUT:set outputBuffer = out ubuffer(data=[0 0 0 0 0 0 0], stride=4)
+RWStructuredBuffer<int> outputBuffer;
+
+bool isAligned<T>(Ptr<T> aligned, size_t expectedAlignment)
+{
+    return (reinterpret<uintptr_t>(aligned) & (expectedAlignment-1)) == 0;
+}
+
+void staticAlignTest() throws MemoryAllocationError
+{
+    bool cases[5] = {true,true,true,true,true};
+
+    for (int i = 0; i < 20; ++i)
+    {
+        // The order is intentionally small->high to ensure that naively allocating
+        // the next free pointer would cause misalignment. Frees are interlaced
+        // to cause additional complications.
+
+        uint8_t* u8ptr = try SystemHeapAllocator.allocate<uint8_t, DefaultDataLayout>();
+        cases[0] = cases[0] && isAligned(u8ptr, 1);
+
+        uint16_t* u16ptr = try SystemHeapAllocator.allocate<uint16_t, DefaultDataLayout>();
+        cases[1] = cases[1] && isAligned(u16ptr, 2);
+        SystemHeapAllocator.free(u8ptr);
+
+        uint* uptr = try SystemHeapAllocator.allocate<uint, DefaultDataLayout>();
+        cases[2] = cases[2] && isAligned(uptr, 4);
+        SystemHeapAllocator.free(u16ptr);
+
+        uint64_t* u64ptr = try SystemHeapAllocator.allocate<uint64_t, DefaultDataLayout>();
+        cases[3] = cases[3] && isAligned(u64ptr, 8);
+        SystemHeapAllocator.free(uptr);
+
+        float4* f4ptr = try SystemHeapAllocator.allocate<float4, DefaultDataLayout>();
+        cases[4] = cases[4] && isAligned(f4ptr, 16);
+        SystemHeapAllocator.free(u64ptr);
+        SystemHeapAllocator.free(f4ptr);
+    }
+
+    // CHECK: 1
+    outputBuffer[0] = cases[0] ? 1 : 0;
+    // CHECK-NEXT: 1
+    outputBuffer[1] = cases[1] ? 1 : 0;
+    // CHECK-NEXT: 1
+    outputBuffer[2] = cases[2] ? 1 : 0;
+    // CHECK-NEXT: 1
+    outputBuffer[3] = cases[3] ? 1 : 0;
+    // CHECK-NEXT: 1
+    outputBuffer[4] = cases[4] ? 1 : 0;
+}
+
+int dynamicAlignTest()
+{
+    // Repeatedly attempt dynamic allocations with various alignments
+    for (int j = 0; j < 20; ++j)
+    {
+        for (int i = 0; i <= 12; ++i)
+        {
+            int alignment = 1<<i;
+            void* addr = nullptr;
+            do
+            {
+                addr = try SystemHeapAllocator.alignedAllocate(alignment*2, alignment);
+            }
+            catch
+            {
+                return alignment;
+            }
+            if (!addr || !isAligned(addr, alignment))
+                return alignment;
+            SystemHeapAllocator.alignedFree(addr);
+        }
+    }
+    return 0;
+}
+
+struct CustomStruct
+{
+    float3 a;
+    float b;
+};
+
+bool reallocTest() throws MemoryAllocationError
+{
+    // Write data, realloc a bit and check that it's still all there.
+    for (int j = 0; j < 20; ++j)
+    {
+        int l1 = 2 * j;
+        int l2 = 4 * j;
+        CustomStruct* addr = try SystemHeapAllocator.allocate<CustomStruct, DefaultDataLayout>(l1);
+        for (int i = 0; i < l1; ++i)
+        {
+            addr[i].a = float3(1.0,2.0,3.0) + i * 4;
+            addr[i].b = 4.0 + i;
+        }
+
+        addr = try SystemHeapAllocator.reallocate<CustomStruct, DefaultDataLayout>(addr, l1, l2);
+        for (int i = 0; i < l1; ++i)
+            if (any(addr[i].a != float3(1.0,2.0,3.0) + i * 4) || addr[i].b != 4.0 + i)
+                return false;
+
+        addr = try SystemHeapAllocator.reallocate<CustomStruct, DefaultDataLayout>(addr, l2, l1);
+        for (int i = 0; i < l1; ++i)
+            if (any(addr[i].a != float3(1.0,2.0,3.0) + i * 4) || addr[i].b != 4.0 + i)
+                return false;
+
+        SystemHeapAllocator.free(addr);
+    }
+    return true;
+}
+
+[numthreads(1,1,1)]
+void computeMain()
+{
+    do
+    {
+        try staticAlignTest();
+    }
+    catch
+    {
+        // Failure
+        outputBuffer[0] = 0;
+        outputBuffer[1] = 0;
+        outputBuffer[2] = 0;
+        outputBuffer[3] = 0;
+        outputBuffer[4] = 0;
+    }
+
+    // CHECK-NEXT: 0
+    outputBuffer[5] = dynamicAlignTest();
+
+    // CHECK-NEXT: 1
+    do
+    {
+        outputBuffer[6] = try reallocTest() ? 1 : 0;
+    }
+    catch
+    {
+        // Failure
+        outputBuffer[6] = 0;
+    }
+}


### PR DESCRIPTION
Reproduction of the diff from shader-slang/slang#10608 for local review-harness iteration.

**Purpose**: baseline PR used by a local dry-run of the review-bot harness. Not intended for merge or review. Opened on the szihs fork, head branch prefixed `claude/` so the fork's own claude-pr-review workflow auto-skips it.

Head branch points at the equivalent of shader-slang/slang@2c4ba38a (PR 10608 head at snapshot time). Base branch pinned at shader-slang/slang@bdee7710 (PR 10608 base at snapshot time).