### PR TITLE
Avoid cached loads from OptiX SBT data

### DIFF
--- a/source/slang/slang-ir-util.cpp
+++ b/source/slang/slang-ir-util.cpp
@@ -3049,6 +3049,10 @@ bool isPointerToImmutableLocation(IRInst* loc)
 {
     switch (loc->getOp())
     {
+    case kIROp_GetOptiXSbtDataPtr:
+        // OptiX SBT data is read-only from shader code, but host code may update it between
+        // launches without invalidating CUDA's read-only cache.
+        return false;
     case kIROp_GetStructuredBufferPtr:
     case kIROp_RWStructuredBufferGetElementPtr:
     case kIROp_ImageSubscript:

--- a/tests/cuda/optix-raygen-sbt-no-ldg.slang
+++ b/tests/cuda/optix-raygen-sbt-no-ldg.slang
@@ -1,0 +1,16 @@
+//TEST:SIMPLE(filecheck=CUDA): -target cuda -entry rayGenA -stage raygeneration -line-directive-mode none
+
+// CUDA: __raygen__rayGenA
+// CUDA-NOT: __ldg
+// CUDA: optixGetSbtDataPointer())->value_0
+// CUDA-NOT: __ldg
+// CUDA: return;
+
+[shader("raygeneration")]
+void rayGenA(RWStructuredBuffer<uint> output, uniform uint value)
+{
+    uint3 index = DispatchRaysIndex();
+    uint3 dim = DispatchRaysDimensions();
+    uint linearIndex = index.y * dim.x + index.x;
+    output[linearIndex] = value + linearIndex;
+}


### PR DESCRIPTION
Fixes CUDA/OptiX raygen SBT parameter loads so they are not lowered to __ldg.\n\nValidation:\n- cmake --build build --target slangc\n- build/Debug/bin/slang-test tests/cuda/optix-raygen-sbt-no-ldg.slang\n- build/Debug/bin/slang-test tests/optimization/defer-structured-buffer-load.slang\n- cmake --build build --target slang-rhi-tests